### PR TITLE
prep for adding go mod support to courtney

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -1,61 +1,136 @@
-// package builder can be used in testing to create a temporary gopath, src, 
+// package builder can be used in testing to create a temporary go module or gopath, src,
 // namespace and package directory, and populate it with source files.
 package builder
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
-
-	"path"
 
 	"github.com/dave/patsy/vos"
 	"github.com/pkg/errors"
 )
 
-// New creates a new gopath in the system temporary location, creates the src
-// dir and the namespace dir. The gopath is appended to the beginning of the 
-// existing gopath, so existing imports will still work. Remember to defer the 
-// Cleanup() method to delete the temporary files.
-func New(env vos.Env, namespace string) (*Builder, error) {
+// New creates a new temporary location, either for a go module or for a gopath root.
+// See NewGoModule or NewGoRoot for the details.
+// Remember to defer the Cleanup() method to delete the temporary files.
+func New(env vos.Env, namespace string, gomod bool) (*Builder, error) {
+	if gomod {
+		return NewGoModule(env, namespace)
+	} else {
+		return NewGoRoot(env, namespace)
+	}
+}
 
+// NewGoRoot creates a new gopath in the system temporary location, creates the src
+// dir and the namespace dir. The gopath is appended to the beginning of the
+// existing gopath, so existing imports will still work.
+// Remember to defer the Cleanup() method to delete the temporary files.
+func NewGoRoot(env vos.Env, namespace string) (*Builder, error) {
 	gopath, err := ioutil.TempDir("", "go")
 	if err != nil {
 		return nil, errors.Wrap(err, "Error creating temporary gopath root dir")
 	}
 
+	// gopath needs to match what `go list` will be returning, so eval symlinks and clean
+	gopath, err = filepath.EvalSymlinks(filepath.Clean(gopath))
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	root := filepath.Join(gopath, "src", namespace)
+
 	b := &Builder{
 		env:       env,
-		root:      gopath,
+		gopath:    gopath,
+		root:      root,
 		namespace: namespace,
+		gomod:     false,
 	}
 
 	if err := os.Mkdir(filepath.Join(gopath, "src"), os.FileMode(0777)); err != nil {
 		b.Cleanup()
 		return nil, errors.Wrap(err, "Error creating temporary gopath src dir")
 	}
-	b.env.Setenv("GOPATH", gopath+string(filepath.ListSeparator)+b.env.Getenv("GOPATH"))
-
-	if err := os.MkdirAll(filepath.Join(gopath, "src", namespace), os.FileMode(0777)); err != nil {
+	if err := os.MkdirAll(root, os.FileMode(0777)); err != nil {
 		b.Cleanup()
 		return nil, errors.Wrap(err, "Error creating temporary namespace dir")
 	}
 
+	err = b.env.Setenv("GOPATH", gopath+string(filepath.ListSeparator)+b.env.Getenv("GOPATH"))
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	// change dir to root to ensure consistent behaviour
+	_ = os.Chdir(gopath)
+	_ = b.env.Setwd(gopath)
+
 	return b, nil
 }
 
-// Builder can be used in testing to create a temporary gopath, src, namespace 
+// NewGoModule creates a new go module root in the system temporary location, creates the root dir
+// and the go.mod file. Remember to defer the Cleanup() method to delete the temporary files.
+func NewGoModule(env vos.Env, namespace string) (*Builder, error) {
+	root, err := ioutil.TempDir("", "go")
+	if err != nil {
+		return nil, errors.Wrap(err, "Error creating temporary gopath root dir")
+	}
+
+	// root needs to match what `go list` will be returning, so eval symlinks and clean
+	root, err = filepath.EvalSymlinks(filepath.Clean(root))
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	b := &Builder{
+		env:       env,
+		gopath:    "",
+		root:      root,
+		namespace: namespace,
+		gomod:     true,
+	}
+
+	err = b.env.Setenv("GOPATH", "")
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	gomodFile := fmt.Sprintf("module %s", namespace)
+	err = ioutil.WriteFile(
+		filepath.Join(root, "go.mod"), []byte(gomodFile), os.FileMode(0666))
+	if err != nil {
+		return nil, errors.Wrap(err, "Error creating temporary go.mod file")
+	}
+
+	// change dir to root to ensure consistent behaviour
+	_ = os.Chdir(root)
+	_ = b.env.Setwd(root)
+
+	return b, nil
+}
+
+// Builder can be used in testing to create a temporary go module or gopath, src, namespace
 // and package directory, and populate it with source files.
 type Builder struct {
 	env       vos.Env // mockable environment
-	root      string  // temporary gopath root dir
+	gopath    string  // temporary gopath root dir
+	root      string  // temporary root dir for namespace
 	namespace string  // temporary namespace
+	gomod     bool    // gomodules enabled or not
+}
+
+// Root returns the temporary gopath root dir.
+func (b *Builder) Root() string {
+	return b.root
 }
 
 // File creates a new source file in the package.
 func (b *Builder) File(packageName, filename, contents string) error {
-	dir := filepath.Join(b.root, "src", b.namespace, packageName)
+	dir := filepath.Join(b.root, packageName)
 	if strings.HasSuffix(filename, ".yaml") || strings.HasSuffix(filename, ".yml") {
 		// most editors will indent multi line strings in Go source with
 		// tabs, so we convert to spaces for yaml files.
@@ -69,8 +144,7 @@ func (b *Builder) File(packageName, filename, contents string) error {
 
 // Package creates a new package and populates with source files.
 func (b *Builder) Package(packageName string, files map[string]string) (packagePath string, packageDir string, err error) {
-
-	dir := filepath.Join(b.root, "src", b.namespace, packageName)
+	dir := filepath.Join(b.root, packageName)
 	if err := os.MkdirAll(dir, 0777); err != nil {
 		return "", "", errors.Wrap(err, "Error creating temporary package dir")
 	}
@@ -88,5 +162,5 @@ func (b *Builder) Package(packageName string, files map[string]string) (packageP
 
 // Cleanup deletes all temporary files.
 func (b *Builder) Cleanup() {
-	os.RemoveAll(b.root)
+	_ = os.RemoveAll(b.root)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/dave/patsy
+
+go 1.12
+
+require github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/patsy_test.go
+++ b/patsy_test.go
@@ -1,11 +1,11 @@
 package patsy_test
 
 import (
+	"fmt"
 	"path"
 	"path/filepath"
-	"testing"
-
 	"strings"
+	"testing"
 
 	"github.com/dave/patsy"
 	"github.com/dave/patsy/builder"
@@ -13,64 +13,75 @@ import (
 )
 
 func TestName2(t *testing.T) {
-	env := vos.Mock()
-	b, err := builder.New(env, "ns")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer b.Cleanup()
+	for _, gomod := range []bool{false, true} {
+		t.Run(fmt.Sprintf("gomod=%v", gomod), func(t *testing.T) {
+			env := vos.Mock()
+			b, err := builder.New(env, "ns", gomod)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer b.Cleanup()
 
-	_, dirA, err := b.Package("a", map[string]string{
-		"a.go": "package a",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
+			_, dirA, err := b.Package("a", map[string]string{
+				"a.go": "package a",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	_, dirB, err := b.Package("b", map[string]string{
-		"b.go": "package b",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
+			_, dirB, err := b.Package("b", map[string]string{
+				"b.go": "package b",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	packagePathC, _, err := b.Package("c", map[string]string{
-		"c.go": "package c",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
+			packagePathC, _, err := b.Package("c", map[string]string{
+				"c.go": "package c",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	// We add a vendored version of "c" inside "b" that has the name "v"
-	_, _, err = b.Package(path.Join("b", "vendor", packagePathC), map[string]string{
-		"c.go": "package v",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
+			// We add a vendored version of "c" inside "b" that has the name "v"
+			_, _, err = b.Package(path.Join("b", "vendor", packagePathC), map[string]string{
+				"c.go": "package v",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	name, err := patsy.Name(env, packagePathC, dirA)
-	if err != nil {
-		t.Fatal(err)
-	}
-	expected := "c"
-	if name != expected {
-		t.Fatalf("Got %s, Expected %s", name, expected)
-	}
+			name, err := patsy.Name(env, packagePathC, dirA)
+			if err != nil {
+				t.Fatal(err)
+			}
+			expected := "c"
+			if name != expected {
+				t.Fatalf("Got %s, Expected %s", name, expected)
+			}
 
-	name, err = patsy.Name(env, packagePathC, dirB)
-	if err != nil {
-		t.Fatal(err)
-	}
-	expected = "v"
-	if name != expected {
-		t.Fatalf("Got %s, Expected %s", name, expected)
+			name, err = patsy.Name(env, packagePathC, dirB)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// without go mod we expect the vendored version of "c"
+			// but with go mod the vendoring is ignored, so we still expect "c"
+			if gomod {
+				expected = "c"
+			} else {
+				expected = "v"
+			}
+			if name != expected {
+				t.Fatalf("Got %s, Expected %s", name, expected)
+			}
+		})
 	}
 }
 
-func TestName(t *testing.T) {
+func TestNameGoPathFromAnywhere(t *testing.T) {
 	env := vos.Mock()
-	b, err := builder.New(env, "ns")
+	b, err := builder.New(env, "ns", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,6 +93,8 @@ func TestName(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// with absolute packagePage we can get the name from any srcDir
 	name, err := patsy.Name(env, packagePath, "/")
 	if err != nil {
 		t.Fatal(err)
@@ -92,10 +105,76 @@ func TestName(t *testing.T) {
 	}
 }
 
-func TestPath(t *testing.T) {
-
+func TestPathGoMod(t *testing.T) {
 	env := vos.Mock()
-	b, err := builder.New(env, "ns")
+	b, err := builder.New(env, "ns", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer b.Cleanup()
+
+	packagePath, packageDir, err := b.Package("a", map[string]string{
+		"a.go": "package b",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	calculatedPath, err := patsy.Path(env, packageDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calculatedPath != packagePath {
+		t.Fatalf("Got %s, Expected %s", calculatedPath, packagePath)
+	}
+}
+
+func TestPathGoPath(t *testing.T) {
+	env := vos.Mock()
+	b, err := builder.New(env, "ns", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer b.Cleanup()
+
+	packagePath, packageDir, err := b.Package("a", map[string]string{
+		"a.go": "package b",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	calculatedPath, err := patsy.Path(env, packageDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calculatedPath != packagePath {
+		t.Fatalf("Got %s, Expected %s", calculatedPath, packagePath)
+	}
+
+	_ = env.Setenv("GOPATH", "/foo/"+string(filepath.ListSeparator)+env.Getenv("GOPATH"))
+
+	calculatedPath, err = patsy.Path(env, packageDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calculatedPath != packagePath {
+		t.Fatalf("Got %s, Expected %s", calculatedPath, packagePath)
+	}
+
+	_ = env.Setenv("GOPATH", "/bar/")
+	_, err = patsy.Path(env, packageDir)
+	if err == nil {
+		t.Fatal("Expected error, got none.")
+	} else if !strings.HasPrefix(err.Error(), "Package not found") {
+		t.Fatalf("Expected 'Package not found', got '%s'", err.Error())
+	}
+}
+
+// In gopath mode we use a fallback to find the dir of an empty package.
+func TestPathNoSrcGoPath(t *testing.T) {
+	env := vos.Mock()
+	b, err := builder.New(env, "ns", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -111,32 +190,64 @@ func TestPath(t *testing.T) {
 		t.Fatal(err)
 	}
 	if calculatedPath != packagePath {
-		t.Fatalf("Got %s, Expected %s", calculatedPath, packagePath)
+		t.Fatalf("Got %s, expected %s", calculatedPath, packagePath)
 	}
+}
 
-	env.Setenv("GOPATH", "/foo/"+string(filepath.ListSeparator)+env.Getenv("GOPATH"))
-
-	calculatedPath, err = patsy.Path(env, packageDir)
+// In gomod mode we don't support empty packages.
+func TestPathNoSrcGoMod(t *testing.T) {
+	env := vos.Mock()
+	b, err := builder.New(env, "ns", true)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if calculatedPath != packagePath {
-		t.Fatalf("Got %s, Expected %s", calculatedPath, packagePath)
+	defer b.Cleanup()
+
+	_, packageDir, err := b.Package("a", nil)
+	if err != nil {
+		t.Fatal(err)
 	}
 
-	env.Setenv("GOPATH", "/bar/")
-	_, err = patsy.Path(env, packageDir)
+	_, err = patsy.Dir(env, packageDir)
 	if err == nil {
 		t.Fatal("Expected error, got none.")
-	} else if !strings.HasPrefix(err.Error(), "Package not found") {
-		t.Fatalf("Expected 'Package not found', got '%s'", err.Error())
+	} else if !strings.HasPrefix(err.Error(), "Dir not found") {
+		t.Fatalf("Expected 'Dir not found', got '%s'", err.Error())
 	}
 }
 
 func TestDir(t *testing.T) {
+	for _, gomod := range []bool{false, true} {
+		t.Run(fmt.Sprintf("gomod=%v", gomod), func(t *testing.T) {
+			env := vos.Mock()
+			b, err := builder.New(env, "ns", gomod)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer b.Cleanup()
 
+			packagePath, packageDir, err := b.Package("a", map[string]string{
+				"a.go": "package b",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			calculatedDir, err := patsy.Dir(env, packagePath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if calculatedDir != packageDir {
+				t.Fatalf("Got %s, expected %s", calculatedDir, packageDir)
+			}
+		})
+	}
+}
+
+// In gopath mode we use a fallback to find the dir of an empty package.
+func TestDirNoSrcGoPath(t *testing.T) {
 	env := vos.Mock()
-	b, err := builder.New(env, "ns")
+	b, err := builder.New(env, "ns", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -154,19 +265,115 @@ func TestDir(t *testing.T) {
 	if calculatedDir != packageDir {
 		t.Fatalf("Got %s, expected %s", calculatedDir, packageDir)
 	}
+}
 
-	err = b.File("a", "a.go", "package a")
+// In gomod mode we don't support empty packages.
+func TestDirNoSrcGoMod(t *testing.T) {
+	env := vos.Mock()
+	b, err := builder.New(env, "ns", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer b.Cleanup()
+
+	packagePath, _, err := b.Package("a", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// TODO: somehow ensure exe.CombinedOutput() succeeds?
-	calculatedDir, err = patsy.Dir(env, packagePath)
-	if err != nil {
-		t.Fatal(err)
+	_, err = patsy.Dir(env, packagePath)
+	if err == nil {
+		t.Fatal("Expected error, got none.")
+	} else if !strings.HasPrefix(err.Error(), "Dir not found") {
+		t.Fatalf("Expected 'Dir not found', got '%s'", err.Error())
 	}
-	if calculatedDir != packageDir {
-		t.Fatalf("Got %s, expected %s", calculatedDir, packageDir)
-	}
+}
 
+func TestDirs(t *testing.T) {
+	for _, gomod := range []bool{false, true} {
+		t.Run(fmt.Sprintf("gomod=%v", gomod), func(t *testing.T) {
+			env := vos.Mock()
+			b, err := builder.New(env, "ns", gomod)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer b.Cleanup()
+
+			packagePath, packageDir, err := b.Package("a", map[string]string{
+				"a.go": "package b",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			calculatedDirs, err := patsy.Dirs(env, packagePath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(calculatedDirs) != 1 || calculatedDirs[packagePath] != packageDir {
+				t.Fatalf("Got %v, expected {%s: %s}", calculatedDirs, packagePath, packageDir)
+			}
+
+			// using . inside a package should give the packageDir as well
+			_ = env.Setwd(packageDir)
+			calculatedDirs, err = patsy.Dirs(env, ".")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(calculatedDirs) != 1 || calculatedDirs[packagePath] != packageDir {
+				t.Fatalf("Got %v, expected map[%s: %s]", calculatedDirs, packagePath, packageDir)
+			}
+		})
+	}
+}
+
+func TestDirsSubpackages(t *testing.T) {
+	for _, gomod := range []bool{false, true} {
+		t.Run(fmt.Sprintf("gomod=%v", gomod), func(t *testing.T) {
+			env := vos.Mock()
+			b, err := builder.New(env, "ns", gomod)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer b.Cleanup()
+
+			packagePathA, packageDirA, err := b.Package("a", map[string]string{
+				"a.go": "package a",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			packagePathB, packageDirB, err := b.Package("a/b", map[string]string{
+				"b.go": "package b",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			packagePathC, packageDirC, err := b.Package("a/c", map[string]string{
+				"c.go": "package c",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			calculatedDirs, err := patsy.Dirs(env, "ns/a/...")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(calculatedDirs) != 3 {
+				t.Fatalf("Got %v, expected 3 packages", calculatedDirs)
+			}
+			if calculatedDirs[packagePathA] != packageDirA {
+				t.Fatalf("Got %s, expected %s", calculatedDirs[packagePathA], packageDirA)
+			}
+			if calculatedDirs[packagePathB] != packageDirB {
+				t.Fatalf("Got %s, expected %s", calculatedDirs[packagePathB], packageDirB)
+			}
+			if calculatedDirs[packagePathC] != packageDirC {
+				t.Fatalf("Got %s, expected %s", calculatedDirs[packagePathC], packageDirC)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Added a `go.mod` file to this repo, just for being modern sake, it came with some minor issues though because both `go/build.Import` and `go list` look at your working dir for a `go.mod` file which was tripping up the tests.  

After realizing that the `go.mod` file being present could affect the results I changed all tests to test both with and without a `go.mod` file.

Finally adding a `Dirs` function which will fetch a list of packages for paths ending with `/...` to replace the recursive code in `courtney` since this is go mod proof.  
And replaced most other functions to use `Dirs` internally, since `go list` is actually pretty good!

not ready for merge yet until review on the courtney PR https://github.com/dave/courtney/pull/21 is done, might need more changes for the courtney PR.