### PR TITLE
Fix separator between import path and directory.

### DIFF
--- a/patsy.go
+++ b/patsy.go
@@ -81,7 +81,7 @@ func Dirs(env vos.Env, packagePath string) (map[string]string, error) {
 		return nil, errors.WithStack(err)
 	}
 
-	exe := exec.Command("go", "list", "-f", "{{.ImportPath}}:{{.Dir}}", packagePath)
+	exe := exec.Command("go", "list", "-f", "{{.ImportPath}}@{{.Dir}}", packagePath)
 	exe.Dir = wd
 	exe.Env = env.Environ()
 	out, err := exe.CombinedOutput()
@@ -98,7 +98,7 @@ func Dirs(env vos.Env, packagePath string) (map[string]string, error) {
 			continue
 		}
 
-		chunks := strings.Split(strings.TrimSpace(line), ":")
+		chunks := strings.Split(strings.TrimSpace(line), "@")
 		importPath := chunks[0]
 		dir := chunks[1]
 


### PR DESCRIPTION
On windows, ":" is problematic because it separates drive letter from path. Thus I changed the separator to "@". This at leas fixed Courtney on Windows.