### PR TITLE
fix: use Dir instead of Dirs in Cache.FilePath

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -128,15 +128,11 @@ func (c *Cache) FilePath(gpath string) (string, error) {
 	ppath, fname := path.Split(gpath)
 	ppath = strings.TrimSuffix(ppath, "/")
 
-	fdirs, err := c.Dirs(ppath)
+	fdir, err := c.Dir(ppath)
 	if err != nil {
 		return "", err
 	}
-	fdir, ok := fdirs[ppath]
-	if !ok {
-		return "", errors.Errorf("Dir not found for %s", gpath)
-	}
-
+	
 	return filepath.Join(fdir, fname), nil
 }
 


### PR DESCRIPTION
The `Cache.FilePath` method was using the `Dirs` method to find the directory for a given package path, but this can result in cache misses because the `dirsCache` may have been populated using a path pattern (e.g. `./...`) that doesn't match the package directory derived from the file path provided. This can result in a confusing slowdown when you know the package directory is in the cache but `Cache.FilePath` still results in calls out to `go list` to find the directory.

The fix is to use the `Dir` method instead of `Dirs` to find the directory for a given package path. I'm assuming that there's no need to support path patterns in `FilePath`.